### PR TITLE
Fix: Updated github workflows to avoid fails due to OS version

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,9 +16,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   generate-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: BobAnkh/auto-generate-changelog@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.9.6
           architecture: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   deploy-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
           python-version: 3.9.6
           architecture: x64

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -45,9 +45,9 @@ jobs:
 
   live-test:
     name: Live Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Pytest coverage comment
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   test:
     name: test py${{ matrix.python-version }} on linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9.6"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install flit==3.6.0

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   type:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.9.6
           architecture: x64


### PR DESCRIPTION
# Change Summary
Fixes #41 

Description:
- Froze the version of `ubuntu` to 20.04 in all `.yml` files
- Updated actions/checkout and actions/setup-python to v3
- Removed the checklist from PR template as there's no need for it (instead we have linter and typer)

- [x] Bug fix (non-breaking change which fixes an issue)
